### PR TITLE
feat: lock plugin runtime version ranges to ~0.1.19

### DIFF
--- a/provisioner_examples_plugin/provisioner_examples_plugin/resources/manifest.json
+++ b/provisioner_examples_plugin/provisioner_examples_plugin/resources/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "provisioner_examples_plugin",
   "version": "0.1.9",
-  "runtime_version_range": "^0.1.0",
+  "runtime_version_range": "~0.1.19",
   "description": "Playground for using the CLI framework with basic dummy commands",
   "author": "Zachi Nachshon",
   "maintainer": "Zachi Nachshon",

--- a/provisioner_installers_plugin/provisioner_installers_plugin/resources/manifest.json
+++ b/provisioner_installers_plugin/provisioner_installers_plugin/resources/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "provisioner_installers_plugin",
   "version": "0.1.6",
-  "runtime_version_range": ">=0.1.15,<0.2.0",
+  "runtime_version_range": "~0.1.19",
   "description": "Install anything anywhere on any OS/Arch either on a local or remote machine",
   "author": "Zachi Nachshon",
   "maintainer": "Zachi Nachshon",

--- a/provisioner_single_board_plugin/provisioner_single_board_plugin/resources/manifest.json
+++ b/provisioner_single_board_plugin/provisioner_single_board_plugin/resources/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "provisioner_single_board_plugin",
   "version": "0.1.5",
-  "runtime_version_range": ">=0.1.10,<0.2.0",
+  "runtime_version_range": "~0.1.19",
   "description": "Single boards management as simple as it gets",
   "author": "Zachi Nachshon",
   "maintainer": "Zachi Nachshon",


### PR DESCRIPTION
- Update examples plugin runtime version range to ~0.1.19

- Update installers plugin runtime version range to ~0.1.19

- Update single board plugin runtime version range to ~0.1.19

This ensures plugins are compatible with the specific runtime version range.